### PR TITLE
Create JointSensors.msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ add_service_files(
   move_com.srv
 )
 
+add_message_files(
+  DIRECTORY msg
+  FILES
+  JointSensors.msg
+)
 generate_messages(DEPENDENCIES geometry_msgs)
 
 catkin_package(

--- a/msg/JointSensors.msg
+++ b/msg/JointSensors.msg
@@ -1,0 +1,5 @@
+Header header
+string[] name
+float64[] motor_temperature
+float64[] driver_temperature
+float64[] motor_current


### PR DESCRIPTION
See https://github.com/jrl-umi3218/mc_rtc/pull/293

This PR will create the `mc_rtc_msgs/JointSensors` ROS msg structure, needed for publishing motor temperature, driver temperature, and motor current readings for a robot joint.